### PR TITLE
Fix mongoose deprecation warnings

### DIFF
--- a/app/config/db.js
+++ b/app/config/db.js
@@ -2,10 +2,10 @@ const mongoose = require('mongoose');
 
 module.exports = async function connectDB() {
   try {
-    await mongoose.connect(process.env.MONGO_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true
-    });
+    // Deprecated options like `useNewUrlParser` and `useUnifiedTopology` are no
+    // longer required with Mongoose 6+. The driver uses them by default, so we
+    // simply pass the connection string.
+    await mongoose.connect(process.env.MONGO_URI);
     console.log('MongoDB connected');
   } catch (err) {
     console.error('MongoDB connection error:', err.message);


### PR DESCRIPTION
## Summary
- remove deprecated `useNewUrlParser` and `useUnifiedTopology` options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847ff2402f48333ac1161656a9dac54